### PR TITLE
Increases usage of dependency injection

### DIFF
--- a/cmpctircd/IRCd.cs
+++ b/cmpctircd/IRCd.cs
@@ -10,6 +10,7 @@
 
     public class IRCd {
         private readonly ISocketListenerFactory socketListenerFactory;
+        private readonly ISocketConnectorFactory socketConnectorFactory;
         private readonly IList<SocketListener> Listeners = new List<SocketListener>();
         public readonly IList<SocketConnector> Connectors = new List<SocketConnector>();
         public PacketManager PacketManager { get; }
@@ -51,10 +52,11 @@
 
         public List<Client> Clients => ClientLists.SelectMany(clientList => clientList).ToList();
         public List<Server> Servers => ServerLists.SelectMany(serverList => serverList).ToList();
-        public IRCd(Log log, CmpctConfigurationSection config, IServiceProvider services, ISocketListenerFactory socketListenerFactory) {
+        public IRCd(Log log, CmpctConfigurationSection config, IServiceProvider services, ISocketListenerFactory socketListenerFactory, ISocketConnectorFactory socketConnectorFactory) {
             this.Log = log;
             this.Config = config;
             this.socketListenerFactory = socketListenerFactory;
+            this.socketConnectorFactory = socketConnectorFactory;
 
             // Interpret the ConfigData
             SID     = config.SID;
@@ -112,7 +114,7 @@
                 if (server.IsOutbound) {
                     // <server> tag with outbound="true"
                     // We want to connect out to this server, not have them connect to us
-                    var sc = new SocketConnector(this, server);
+                    var sc = socketConnectorFactory.CreateSocketConnector(this, server);
                     Log.Info($"==> Connecting to: {server.Destination}:{server.Port} ({server.Host}) ({(server.IsTls ? "TLS" : "Plain" )})");
 
                     Connectors.Add(sc);

--- a/cmpctircd/ISocketConnectorFactory.cs
+++ b/cmpctircd/ISocketConnectorFactory.cs
@@ -1,0 +1,7 @@
+﻿using cmpctircd.Configuration;
+
+namespace cmpctircd {
+    public interface ISocketConnectorFactory {
+        SocketConnector CreateSocketConnector(IRCd ircd, ServerElement config);
+    }
+}

--- a/cmpctircd/ISocketListenerFactory.cs
+++ b/cmpctircd/ISocketListenerFactory.cs
@@ -1,0 +1,7 @@
+﻿using cmpctircd.Configuration;
+
+namespace cmpctircd {
+    public interface ISocketListenerFactory {
+        SocketListener CreateSocketListener(IRCd ircd, SocketElement config);
+    }
+}

--- a/cmpctircd/Program.cs
+++ b/cmpctircd/Program.cs
@@ -28,6 +28,7 @@
                     services.AddScoped<IrcContext>();
                     services.AddScoped(sp => sp.GetRequiredService<IrcContext>().Sender as Client);
                     services.AddScoped(sp => sp.GetRequiredService<IrcContext>().Sender as Server);
+                    services.AddTransient<ISocketListenerFactory, SocketListenerFactory>();
                     services.AddHostedService<IrcApplicationLifecycle>();
                 });
         }

--- a/cmpctircd/Program.cs
+++ b/cmpctircd/Program.cs
@@ -29,6 +29,7 @@
                     services.AddScoped(sp => sp.GetRequiredService<IrcContext>().Sender as Client);
                     services.AddScoped(sp => sp.GetRequiredService<IrcContext>().Sender as Server);
                     services.AddTransient<ISocketListenerFactory, SocketListenerFactory>();
+                    services.AddTransient<ISocketConnectorFactory, SocketConnectorFactory>();
                     services.AddHostedService<IrcApplicationLifecycle>();
                 });
         }

--- a/cmpctircd/SocketConnector.cs
+++ b/cmpctircd/SocketConnector.cs
@@ -9,14 +9,15 @@ using cmpctircd.Configuration;
 
 namespace cmpctircd {
     public class SocketConnector : SocketListener {
-
+        private readonly Log log;
         public ServerElement ServerInfo;
         public bool Connected;
         private TcpClient tc;
         private NetworkStream stream;
 
 
-        public SocketConnector(IRCd ircd, ServerElement info) : base(ircd, info) {
+        public SocketConnector(Log log, IRCd ircd, ServerElement info) : base(log, ircd, info) {
+            this.log = log ?? throw new ArgumentNullException(nameof(log));
             ServerInfo = info;
         }
 

--- a/cmpctircd/SocketConnector.cs
+++ b/cmpctircd/SocketConnector.cs
@@ -39,7 +39,7 @@ namespace cmpctircd {
                 await tc.ConnectAsync(Info.Host.ToString(), Info.Port);
                 stream = tc.GetStream();
             } catch (SocketException) {
-                _ircd.Log.Warn($"Unable to connect to server {Info.Host.ToString()}:{Info.Port}");
+                log.Warn($"Unable to connect to server {Info.Host.ToString()}:{Info.Port}");
                 return;
             }
 

--- a/cmpctircd/SocketConnectorFactory.cs
+++ b/cmpctircd/SocketConnectorFactory.cs
@@ -1,0 +1,16 @@
+﻿using cmpctircd.Configuration;
+using System;
+
+namespace cmpctircd {
+    public class SocketConnectorFactory : ISocketConnectorFactory {
+        private readonly Log log;
+
+        public SocketConnectorFactory(Log log) {
+            this.log = log ?? throw new ArgumentNullException(nameof(log));
+        }
+
+        public SocketConnector CreateSocketConnector(IRCd ircd, ServerElement config) {
+            return new SocketConnector(log, ircd, config);
+        }
+    }
+}

--- a/cmpctircd/SocketListener.cs
+++ b/cmpctircd/SocketListener.cs
@@ -45,7 +45,7 @@ namespace cmpctircd {
         }
         public virtual void Stop() {
             if (_started) {
-                _ircd.Log.Debug($"Shutting down listener [IP: {Info.Host}, Port: {Info.Port}, TLS: {Info.IsTls}]");
+                log.Debug($"Shutting down listener [IP: {Info.Host}, Port: {Info.Port}, TLS: {Info.IsTls}]");
                 _listener.Stop();
                 _started = false;
             }
@@ -63,7 +63,7 @@ namespace cmpctircd {
                     TcpClient tc = await _listener.AcceptTcpClientAsync();
                     HandleClientAsync(tc); // this should split off execution
                 } catch(Exception e) {
-                    _ircd.Log.Error($"Exception in ListenToClients(): {e.ToString()}");
+                    log.Error($"Exception in ListenToClients(): {e.ToString()}");
                 }
             }
         }
@@ -74,7 +74,7 @@ namespace cmpctircd {
                 try {
                     stream = await HandshakeTlsAsServerAsync(tc);
                 } catch (Exception e) {
-                    _ircd.Log.Debug($"Exception in {nameof(HandshakeTlsAsServerAsync)}: {e}");
+                    log.Debug($"Exception in {nameof(HandshakeTlsAsServerAsync)}: {e}");
                     tc.Close();
                 }
             }
@@ -191,7 +191,7 @@ namespace cmpctircd {
             if (verifyCert) {
                 stream = new SslStream(tc.GetStream(), true);
             } else {
-                _ircd.Log.Warn($"[SERVER] Connecting out to server {host} with TLS verification disabled: this is dangerous!");
+                log.Warn($"[SERVER] Connecting out to server {host} with TLS verification disabled: this is dangerous!");
                 stream = new SslStream(tc.GetStream(), true, (sender, certificate, chain, sslPolicyErrors) => true);
             }
 

--- a/cmpctircd/SocketListener.cs
+++ b/cmpctircd/SocketListener.cs
@@ -26,7 +26,8 @@ namespace cmpctircd {
         public int ServerCount = 0;
         public int AuthServerCount = 0;
 
-        public SocketListener(IRCd ircd, SocketElement info) {
+        public SocketListener(Log log, IRCd ircd, SocketElement info) {
+            this.log = log ?? throw new ArgumentNullException(nameof(log));
             this._ircd = ircd;
             this.Info = info;
             _listener = new TcpListener(info.Host, info.Port);

--- a/cmpctircd/SocketListener.cs
+++ b/cmpctircd/SocketListener.cs
@@ -12,6 +12,7 @@ using cmpctircd.Configuration;
 
 namespace cmpctircd {
     public class SocketListener {
+        private readonly Log log;
         protected IRCd _ircd;
         private Boolean _started = false;
         private TcpListener _listener = null;

--- a/cmpctircd/SocketListenerFactory.cs
+++ b/cmpctircd/SocketListenerFactory.cs
@@ -1,0 +1,9 @@
+﻿using cmpctircd.Configuration;
+
+namespace cmpctircd {
+    public class SocketListenerFactory : ISocketListenerFactory {
+        public SocketListener CreateSocketListener(IRCd ircd, SocketElement config) {
+            return new SocketListener(ircd, config);
+        }
+    }
+}

--- a/cmpctircd/SocketListenerFactory.cs
+++ b/cmpctircd/SocketListenerFactory.cs
@@ -1,9 +1,16 @@
 ﻿using cmpctircd.Configuration;
+using System;
 
 namespace cmpctircd {
     public class SocketListenerFactory : ISocketListenerFactory {
+        private readonly Log log;
+
+        public SocketListenerFactory(Log log) {
+            this.log = log ?? throw new ArgumentNullException(nameof(log));
+        }
+
         public SocketListener CreateSocketListener(IRCd ircd, SocketElement config) {
-            return new SocketListener(ircd, config);
+            return new SocketListener(log, ircd, config);
         }
     }
 }


### PR DESCRIPTION
This is a first draft to demonstrate how we can use factories to inject services into objects which are created after startup.

The factories are created at startup, with necessary services injected, and pass these into the constructors of the objects they create. 

In the factories submitted so far, I have injected the Log object to construct SocketListener/SocketConnector. The IRCd class no longer needs to know that these classes require a Log.

Unfortunately I couldn't inject the IRCd class into the factory because it would have been a circular dependency.

Any thoughts?